### PR TITLE
feat: Hide list menu on mobile

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -94,7 +94,7 @@
   }
 
   .list-menu--inline {
-    display: flex;
+    display: none;
     flex-wrap: wrap;
     @media screen and (min-width: 990px) {
     display: flex;/*why is this showing as inline*/


### PR DESCRIPTION
Hides the list menu on mobile devices by setting the
display property to 'none'. This change is made to
improve the layout and user experience on smaller
screens.