### PR TITLE
feat: Remove text underline from predictive search title

### DIFF
--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -110,7 +110,7 @@ predictive-search[loading] .predictive-search {
     font-family: var(--font-menu-sub);
     color: #1C2936;
     text-transform: uppercase;
-    text-decoration: underline;
+    text-decoration: none;
     }
 }
 


### PR DESCRIPTION
The changes in this commit remove the underline from the predictive search
title. This is done to improve the overall visual appearance and
consistency of the search component.