### PR TITLE
feat(header): Adjust the positioning of the inverted body

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -38,8 +38,8 @@
 
   @media screen and (min-width: 990px) {
     .inverted-body {
-    top: -150px;
-    margin-bottom: -150px;
+    top: -214px;
+    margin-bottom: -214px;
    
 
   }


### PR DESCRIPTION
Increase the top and bottom margin of the inverted body element
to 214px to ensure it aligns properly with the header content
on smaller screens when navigation wraps onto two lines