### PR TITLE
feat: Adjust focus box-shadow color for better contrast

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1753,7 +1753,7 @@ details[open] > .share-button__fallback {
 .customer .field input:focus,
 .customer select:focus,
 .localization-form__select:focus.localization-form__select:after {
-  box-shadow: 0 0 0 calc(0.1rem + var(--inputs-border-width)) rgba(var(--color-foreground));
+  box-shadow: 0 0 0 calc(0.1rem + var(--inputs-border-width)) hsla(260, 11%, 95%, 1);
   outline: 0;
   border-radius: var(--inputs-radius);
 }


### PR DESCRIPTION
Modify the focus box-shadow color for input fields, select dropdowns, and
the localization form select to improve the contrast and accessibility
of the focused state. The previous color had insufficient contrast
against the background, so it is updated to a lighter gray that
provides better visibility.