### PR TITLE
feat: Improve hover styles for secondary product button

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1367,7 +1367,7 @@ button.shopify-payment-button__button--unbranded {
   --border-opacity: var(--buttons-border-opacity);
 }
 
-.button--secondary:hover {
+.product-form__submit.button--secondary:hover {
   background-color: #3c4140;
   color: #FFF;
   transition: background-color 0.3s ease-in-out;


### PR DESCRIPTION
Modify the CSS rule for the secondary product form button to
include the specific `.product-form__submit` class. This ensures
the hover styles are only applied to the secondary product
submission button, and not any other secondary buttons on the
page.