### PR TITLE
feat(related-products): Add spacing to related products section

### DIFF
--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -52,7 +52,7 @@
       align-items: center;
       margin: 0 2rem;
       max-width: 917px;
-     margin: 0 auto;
+      margin: 1rem auto 4rem auto;
       /* @media screen and (min-width: 750px) {
         display: none;
       } */
@@ -379,7 +379,7 @@
       const indicatorSegments = document.querySelectorAll('.slider-indicator__segment');
       const prevButton = document.querySelector('.slider-control--prev');
       const nextButton = document.querySelector('.slider-control--next');
-      
+
       if (!slider || indicatorSegments.length === 0 || !prevButton || !nextButton) {
         console.error('Slider elements not found');
         return;


### PR DESCRIPTION
This commit adds margin to the related products section to improve the
spacing and layout. Specifically, the top and bottom margins have been
increased to 1rem and 4rem respectively to create more visual
separation from the surrounding content.