### PR TITLE
feat(header): Remove inverted navigation on close

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -838,7 +838,7 @@ Navigation Inversion
       elements.headerWrapperBosie.classList.remove(classActions.remove[0]);
     } else {
       elements.mainContent.classList.remove(classActions.add[0]); 
-      // elements.headerWrapper.classList.remove(classActions.add[1]);
+      elements.headerWrapper.classList.remove(classActions.add[1]);
       elements.searchText.classList.remove(classActions.add[2]);
       elements.menuItems.forEach(item => item.classList.remove(classActions.add[2]));
       removeClassFromSVG(elements.headerLogo, classActions.add[3]);
@@ -904,6 +904,9 @@ Navigation Inversion
   }
 
   function removeInvertedNav() {
+    if (document.querySelector('.inverted-navigation')) {
+      setInvertedNavigation(false);
+    }
     
   }
 


### PR DESCRIPTION
Removes the inverted navigation styles when the user closes the
navigation menu. This ensures that the header returns to its
default state and appearance after the menu is closed.