### PR TITLE
feat(header): Adjust menu item padding for smaller screens

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2984,6 +2984,12 @@ details[open] > .header__submenu {
   color: rgba(var(--color-foreground), 0.75);
   
 }
+@media screen and (max-width: 1174px) {
+
+.header__menu-item {
+  padding: 2.2rem 0.8rem;
+  }
+  }
 .header__menu-item svg {
   margin-left: 0.8rem;
 }


### PR DESCRIPTION
The changes made in this commit adjust the padding of the header menu items
to ensure they are properly displayed on smaller screens. The media query
targets screens with a maximum width of 1174px and reduces the padding of
the `.header__menu-item` elements to 2.2rem 0.8rem.