### PR TITLE
feat(header): Adjust logo position and remove trailing newline

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -352,7 +352,7 @@ position: relative;
 
 .caption-logo {
   position: absolute;
-  top: 50%;
+  top: 44%;
   left: 50%;
   transform: translate(-50%, -50%);
   width: 17rem;


### PR DESCRIPTION
The changes in this commit include:

1. Adjusting the vertical position of the caption logo in the header
   section from 50% to 44% of the parent container's height. This
   ensures the logo is visually centered within the header.

2. Removing the trailing newline at the end of the `header.liquid`
   file. This maintains a consistent file structure and avoids
   unnecessary whitespace.