### PR TITLE
feat(dropdown): Simplify product note display

### DIFF
--- a/assets/uncover-dropdown.js
+++ b/assets/uncover-dropdown.js
@@ -55,9 +55,9 @@ class UncoverDropdown extends HTMLElement {
       }
       brushingProduct.dataset.price = optionRawPrice;
       brushingProduct.dataset.id = optionID;
-      brushingProduct.dataset.note = `${optionTitle} (+ ${formatMoney(optionRawPrice, currencyFormat)})`;
+      brushingProduct.dataset.note = `${optionTitle}`;
 
-      this.updateProductNote(`${optionTitle} (+ ${formatMoney(optionRawPrice, currencyFormat)})`);
+      this.updateProductNote(`${optionTitle}`);
       this.updateProductPrice(optionRawPrice);
     } else {
       dropdownArrow.querySelector('svg').style.display = 'block';


### PR DESCRIPTION
Simplifies the product note display by removing the price
information from service. This makes the note more concise and focused on
the product title.