### PR TITLE
feat: Hide tax note in cart component

### DIFF
--- a/assets/component-cart.css
+++ b/assets/component-cart.css
@@ -189,7 +189,7 @@ cart-items {
 .tax-note {
   margin: 2.2rem 0 1.6rem auto;
   text-align: center;
-  display: block;
+  display: none;
 }
 
 .cart__checkout-button {


### PR DESCRIPTION
Hides the tax note in the cart component as it is not
currently being used and clutters the UI. This change
improves the overall user experience by removing
unnecessary elements from the cart.